### PR TITLE
Fix - Player model visible on stairs

### DIFF
--- a/COGITO/SteamP2PCoop/MultiplayerPlayer.tscn
+++ b/COGITO/SteamP2PCoop/MultiplayerPlayer.tscn
@@ -6,15 +6,6 @@
 [ext_resource type="Material" uid="uid://c4rvflucftsrl" path="res://COGITO/DynamicFootstepSystem/Assets/Materials/Example_Wood.tres" id="4_d2a6w"]
 [ext_resource type="Material" uid="uid://dkbgl3p3ffd1" path="res://COGITO/Assets/Materials/Prototype_DarkGrey.tres" id="5_5o2oq"]
 
-[sub_resource type="CapsuleMesh" id="CapsuleMesh_vlq2o"]
-material = ExtResource("4_d2a6w")
-radius = 0.4
-height = 1.7
-
-[sub_resource type="BoxMesh" id="BoxMesh_6opph"]
-material = ExtResource("5_5o2oq")
-size = Vector3(0.5, 0.25, 0.5)
-
 [sub_resource type="SceneReplicationConfig" id="SceneReplicationConfig_do35g"]
 properties/0/path = NodePath(".:sync_position")
 properties/0/spawn = true
@@ -26,6 +17,15 @@ properties/2/path = NodePath(".:sync_velocity")
 properties/2/spawn = true
 properties/2/replication_mode = 1
 
+[sub_resource type="CapsuleMesh" id="CapsuleMesh_vlq2o"]
+material = ExtResource("4_d2a6w")
+radius = 0.4
+height = 1.7
+
+[sub_resource type="BoxMesh" id="BoxMesh_6opph"]
+material = ExtResource("5_5o2oq")
+size = Vector3(0.5, 0.25, 0.5)
+
 [node name="PlayerP2PCoop" instance=ExtResource("1_kpc5f")]
 script = ExtResource("2_0gpnc")
 sync_weight = 0.2
@@ -33,10 +33,18 @@ sync_weight = 0.2
 [node name="Camera" parent="Neck/Head/Eyes" index="1"]
 script = ExtResource("3_pg1i5")
 
-[node name="PlayerCapsuleMeshInstance3D" type="MeshInstance3D" parent="." index="15"]
-mesh = SubResource("CapsuleMesh_vlq2o")
+[node name="MultiplayerSynchronizer" type="MultiplayerSynchronizer" parent="." index="15"]
+replication_interval = 0.1
+delta_interval = 0.1
+replication_config = SubResource("SceneReplicationConfig_do35g")
 
-[node name="PlayerGlassesMeshInstance3D" type="MeshInstance3D" parent="PlayerCapsuleMeshInstance3D" index="0"]
+[node name="PlayerModel" type="Node3D" parent="." index="17"]
+
+[node name="PlayerCapsuleMeshInstance3D" type="MeshInstance3D" parent="PlayerModel" index="0"]
+mesh = SubResource("CapsuleMesh_vlq2o")
+skeleton = NodePath("../..")
+
+[node name="PlayerGlassesMeshInstance3D" type="MeshInstance3D" parent="PlayerModel/PlayerCapsuleMeshInstance3D" index="0"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.667003, -0.0824701)
 mesh = SubResource("BoxMesh_6opph")
 

--- a/COGITO/SteamP2PCoop/multiplayer_player.gd
+++ b/COGITO/SteamP2PCoop/multiplayer_player.gd
@@ -11,6 +11,7 @@ func _enter_tree():
 	## when the game is starting single player mode we don't want to lose authority
 	if not multiplayer.multiplayer_peer is OfflineMultiplayerPeer:
 		set_multiplayer_authority(name.to_int())
+	_disable_local_playermodel()
 
 
 func _input(event):
@@ -36,3 +37,11 @@ func _client_sync():
 	global_rotation = global_rotation.lerp(sync_rotation, sync_weight)
 	velocity = sync_velocity
 	move_and_slide()
+
+
+func _disable_local_playermodel():
+	var player_model = $PlayerModel
+	if is_multiplayer_authority():
+		player_model.visible = false
+	else:
+		player_model.visible = true

--- a/COGITO/SteamP2PCoop/steam_p2p_manager.gd
+++ b/COGITO/SteamP2PCoop/steam_p2p_manager.gd
@@ -13,7 +13,7 @@ func _ready():
 	
 	## if steam did not initialize properly then shut down
 	if initialize_response['status'] > 0:
-		print("Failed to initialize Steam, shutting down: %s" % initialize_response)
+		printerr("Failed to initialize Steam, shutting down: %s" % initialize_response)
 		get_tree().quit()
 
 


### PR DESCRIPTION
Fixed self player model visibility on stairs in MP by just hiding the player model locally

Encountered an issue where occasionally when running, and most of the time when going down stairs, the players own player model would become visible. 

![image](https://github.com/user-attachments/assets/e69ba803-e625-4894-ad7f-0fba8c3379c9)

Now appears the same as singleplayer, i.e. no visible self player model when moving on stairs

also better feedback from the "Failed to initialize Steam" by switching it to a Printerr instead of just print. Think this is needed as it causes a quit so should throw an error.