### PR TITLE
Only call player ready when its the local player

### DIFF
--- a/addons/cogito/SteamP2PCoop/Synchronizers/cogito_pickup_synchronizer.gd
+++ b/addons/cogito/SteamP2PCoop/Synchronizers/cogito_pickup_synchronizer.gd
@@ -12,7 +12,7 @@ func _ready():
 
 
 func _on_multiplayer_level_spawner_level_loaded():
-	pickup_array = level_spawner.find_children("", "CogitoPickupComponent", true, false)
+	pickup_array = level_spawner.find_children("", "PickupComponent", true, false)
 	for pickup in pickup_array:
 		pickup.was_interacted_with.connect(_on_pickup.bind(pickup))
 

--- a/addons/cogito/SteamP2PCoop/multiplayer_player.gd
+++ b/addons/cogito/SteamP2PCoop/multiplayer_player.gd
@@ -18,6 +18,12 @@ extends CogitoPlayer
 ## This is to prevent lerping from the starting sync values (0,0,0)
 var synced_after_spawn = false
 
+## only call ready when its the local player, so that the local player remains the referenced player in the local scene manager
+func _ready():
+	if name == str(multiplayer.get_unique_id()):	
+		CogitoSceneManager._player_state = CogitoSceneManager.get_existing_player_state(CogitoSceneManager._active_slot) 
+		super()
+
 func _enter_tree():
 	## when the game is starting single player mode we don't want to lose authority
 	if not multiplayer.multiplayer_peer is OfflineMultiplayerPeer:


### PR DESCRIPTION
Before when you try to save as host you would get the error: Attempt to call function 'save' in base 'previously freed' on a null instance.

because the newly created client player instance made itself the new player node in the cogito_scene_manager of the host in the normal _ready() function. Then when saving as the host it would try to save the current_player_interaction_component of this non-local player node, which would have been freed in the _enter_tree() function because it is not the local player node.

So the solution I propose is to only call the normal _ready() function if it is the local player.